### PR TITLE
Added MPS support for Apple Silicon GPU compatibility

### DIFF
--- a/vocal/__init__.py
+++ b/vocal/__init__.py
@@ -141,6 +141,9 @@ def get_model(device: str):
   from huggingface_hub import hf_hub_download
 
   device = device.lower()
+  variant = "cuda" if device == "mps" else device
+  
   return torch.jit.load(
-    hf_hub_download("seanghay/vocalfile", f"UVR-MDX-NET-Voc_FT.{device}.pt")
+    hf_hub_download("seanghay/vocalfile", f"UVR-MDX-NET-Voc_FT.{variant}.pt"),
+    map_location=device if device == "mps" else None
   ).to(device)  # Move model to GPU immediately

--- a/vocal/cli.py
+++ b/vocal/cli.py
@@ -25,7 +25,7 @@ from typing import List
 @click.option(
   "-d",
   "--device",
-  default="cuda" if torch.cuda.is_available() else "cpu",
+  default="cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu",
   help="Device",
 )
 @click.option(


### PR DESCRIPTION
## Add MPS device support for Apple Silicon

**Problem**

Specifying `--device mps` failed despite Apple Silicon GPUs being available. Device detection didn't recognize MPS, and model loading assumed CUDA/CPU only. The CUDA model works fine on Apple Silicone GPUs.

**Changes**

1. **Device detection**: Added MPS to supported devices
2. **Model loading**: Added `map_location` parameter when device is MPS to handle tensor relocation
3. **Model name mapping**: MPS now maps to CUDA model variants (HuggingFace convention uses `cuda` in model names for GPU-accelerated versions)

**Impact**

Apple Silicon users can now use GPU acceleration with `--device mps` instead of falling back to CPU. The default `--device` will also be `mps` if that is supported (just like `cuda`).

**Technical note**

HuggingFace model naming uses `cuda` for any GPU variant, not device-specific names. The mapping `mps -> cuda` reflects this convention, not a device equivalence.